### PR TITLE
Change the history to reflect correct speakers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,13 +331,13 @@
                     <td>Wed 7th Nov</td><td><b>Chris Alcock</b> Web Sockets and SignalR</td>
                   </tr>
                   <tr>
-                    <td>Thur 18th Oct</td><td><b>Chris Alcock</b> Tentative Steps in Windows 8 UI-Style Apps with Windows Azure and the WebApi</td>
+                    <td>Thur 18th Oct</td><td><b>Steve Morgan</b> Tentative Steps in Windows 8 UI-Style Apps with Windows Azure and the WebApi</td>
                   </tr>
                   <tr>
-                    <td>Thur 13th Sept</td><td><b>Richard Costall</b>5 Months in MVC</td>
+                    <td>Thur 13th Sept</td><td><b>Richard Costall</b> 5 Months in MVC</td>
                   </tr>
                   <tr>
-                    <td>Wed 8th August</td><td><b>Chris Alcock</b>Jimmy Talks OAuth</td>
+                    <td>Wed 8th August</td><td><b>Jimmy Skowronski</b> Jimmy Talks OAuth</td>
                   </tr>
                   <tr>
                     <td>26 July 2012</td><td><b>Andrew Westgarth</b> IIS 8.0 Platform For The Future</td>


### PR DESCRIPTION
I noticed that Chirs Alcock had be referenced as the speaker to a number of sessions.

Thanks to the wayback machine I was able to get the correct ones.
